### PR TITLE
maven compile error fix

### DIFF
--- a/spring-boot-samples/spring-boot-sample-atmosphere/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-atmosphere/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-samples</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.2.4.RELEASE</version>
 	</parent>
 	<artifactId>spring-boot-sample-atmosphere</artifactId>
 	<name>Spring Boot Atmosphere Sample</name>

--- a/spring-boot-samples/spring-boot-sample-atmosphere/pom.xml
+++ b/spring-boot-samples/spring-boot-sample-atmosphere/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<!-- Your own application should inherit from spring-boot-starter-parent -->
 		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
+		<artifactId>spring-boot-starter-samples</artifactId>
 		<version>2.2.4.RELEASE</version>
 	</parent>
 	<artifactId>spring-boot-sample-atmosphere</artifactId>


### PR DESCRIPTION
this will fix the maven file compile error for future students taking your pluralsight Jenkins 2 class.

Fix described in this stackexchange [question.](https://stackoverflow.com/questions/60034707/maven-compile-error-error-non-resolvable-import-pom-could-not-transfer-arti) 

Was able to manually build after applying these changes. 
root@cc3bd1857272:/var/jenkins_home/workspace/atmosphere2/spring-boot-samples/spring-boot-sample-atmosphere# mvn compile
...
...
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35.893 s
[INFO] Finished at: 2020-04-04T03:26:05+00:00
[INFO] Final Memory: 34M/196M
[INFO] ------------------------------------------------------------------------

